### PR TITLE
Changed textInput text "New Sketch" to placeholder "New Sketch"

### DIFF
--- a/javascripts/sketch.js
+++ b/javascripts/sketch.js
@@ -359,7 +359,8 @@ function setup() { // jshint ignore:line
 
     // Upper right
     // Input field for the file name
-    textInput = createInput('New Sketch');
+    textInput = createInput('');
+    textInput.attribute('placeholder','New Sketch');
     textInput.size(200, 15);
     textInput.position(windowWidth - textInput.width - 203, 4);
 


### PR DESCRIPTION
The text, as a placeholder, is now grey. As soon as someone types something in the textbox, the text "New Sketch" is replaced by the typed text.